### PR TITLE
Remove `-output-directory` argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,6 @@ function latex (src, options) {
 
     const args = [
       '-halt-on-error',
-      `-output-directory=${tempPath}`
     ]
 
     const opts = {


### PR DESCRIPTION
LaTeX's `-output-directory` argument has weird semantics; it was causing
LaTeX to fail to compile documents that began with a comment line.  This
option is not necessary anyway, because the LaTeX child process is
spawned with `cwd` equal to the output directory.

Fix #2.