### PR TITLE
Add support for multi-pass documents

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,5 +29,7 @@ latex(input).pipe(output)
 
 **options.cmd** \[String\] - The command to run for your document (`pdflatex`, `xetex`, etc). `pdflatex` is the default.
 
+**options.passes** \[Number\] - The number of times to run `options.cmd`. Some documents require multiple passes. Only works when `doc` is a String. Defaults to `1`.
+
 ## License
 MIT


### PR DESCRIPTION
Add a parameter `options.passes`, which determines how many times
`options.cmd` is run.  Only works when `doc` is a String because streams
can't be consumed multiple times. Defaults to `1`.

Close #1.
Requires #3.
