### PR TITLE
Remove binary name resrictions

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,14 +39,11 @@ function latex (src, options) {
     let inputs = options.inputs || tempPath
     let cmd = options.cmd || 'pdflatex'
 
-    const isTexCmd = (cmd) => ['pdflatex', 'xetex', 'latex'].indexOf(cmd) !== -1
-
     const joinInputs = (inputs) =>
       Array.isArray(inputs)
         ? inputs.join(':') + ':'
         : inputs + ':'
 
-    cmd = isTexCmd(cmd) ? cmd : 'pdflatex'
     inputs = joinInputs(inputs)
 
     const args = [


### PR DESCRIPTION
Remove the restrictions on `options.cmd`, as this breaks the
following use cases:

- Specifying the full path to the binary when it is not in `$PATH`
  or running in an environment where `$PATH` is not set, such as
  some init daemons and service managers.

- Having multiple binaries installed with the version number
  appended to the binary name.

- Accessing the binary via a symlink of a different name.