### PR TITLE
listening to stdout and stderr with dummy function

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ function latex(src, options) {
         ? `${inputs.join(':')}:`
         : `${inputs}:`
 
-    const args = [
+    const args = options.args || [
       '-halt-on-error'
     ]
 

--- a/index.js
+++ b/index.js
@@ -146,6 +146,12 @@ function latex(src, options) {
         handleErrors(new Error(`Error: Unable to run ${cmd} command.`))
       })
 
+      tex.stdout.on('data', (data) => {});
+
+      tex.stderr.on('data', (data) => {});
+
+      tex.on('close', (code) => {});
+
       tex.on('exit', (code) => {
         if (code !== 0) {
           printErrors(tempPath, userLogPath)

--- a/readme.md
+++ b/readme.md
@@ -31,6 +31,8 @@ latex(input).pipe(output)
 
 **options.cmd** \[String\] - The command to run for your document (`pdflatex`, `xetex`, etc). `pdflatex` is the default.
 
+**options.args** \[Array<String>\] - Arguments passed to `cmd`. Defaults to `['-halt-on-error']`.
+
 **options.passes** \[Number\] - The number of times to run `options.cmd`. Some documents require multiple passes. Only works when `doc` is a String. Defaults to `1`.
 
 **options.errorLogs** \[String] - The path to the file where you want to save the contents of the error log to.


### PR DESCRIPTION
Otherwise, child processes can stall if they produce a lot of output in the buffers. At some point the internal buffer is filling up and the built-in backpressure mechanism causes the process to stop accepting output from the child.