### PR TITLE
add capacity to use relative paths in options

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ function latex(src, options) {
     const errorLogStream = fs.createReadStream(errorLogPath)
 
     if (userLogPath) {
-      const userLogStream = fs.createWriteStream(userLogPath)
+      const userLogStream = fs.createWriteStream(path.resolve(userLogPath))
       errorLogStream.pipe(userLogStream)
     }
 

--- a/index.js
+++ b/index.js
@@ -84,11 +84,18 @@ function latex(src, options) {
 
     options = options || {}
 
+    function resolvePaths(paths) {
+      if (Array.isArray(paths)) {
+        return paths.map(pth => path.resolve(pth))
+      }
+      return path.resolve(paths)
+    }
+
     // The path(s) to your TEXINPUTS.
-    const inputs = options.inputs || tempPath
+    const inputs = options.inputs ? resolvePaths(options.inputs) : tempPath
 
     // The path(s) to your font inputs for fontspec.
-    const fonts = options.fonts || tempPath
+    const fonts = options.fonts ? resolvePaths(options.fonts) : tempPath
 
     // The binary command to run (`pdflatex`, `xetex`, etc).
     const cmd = options.cmd || 'pdflatex'

--- a/readme.md
+++ b/readme.md
@@ -34,9 +34,9 @@ View more examples [here](https://github.com/saadq/node-latex/tree/master/exampl
 
 **doc** \[ReadableStream|String\] *Required* - The (La)TeX document you want to use.
 
-**options.inputs** \[String|Array<String>\] - The absolute path (or an array of absolute paths) to the directory which contains the assets necessary for the doc.
+**options.inputs** \[String|Array<String>\] - The path (or an array of paths) to the directory which contains the assets necessary for the doc.
 
-**options.fonts** \[String|Array<String>\] - The absolute path (or an array of absolute paths) to the directory which contains the fonts necessary for the doc (you will most likely want to use this option if you're working with `fontspec`).
+**options.fonts** \[String|Array<String>\] - The path (or an array of paths) to the directory which contains the fonts necessary for the doc (you will most likely want to use this option if you're working with `fontspec`).
 
 **options.cmd** \[String\] - The command to run for your document (`pdflatex`, `xetex`, etc). `pdflatex` is the default.
 


### PR DESCRIPTION
Permits users to pass relative paths to options.inputs and options.fonts; closes #26  :-) 