### PR TITLE
Specify `-jobname=texput` in LaTeX compiler args.

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,6 +126,7 @@ function latex(src, options) {
     const args = options.args || [
       '-halt-on-error'
     ]
+    args.push('-jobname=texput')
 
     const opts = {
       cwd: tempPath,


### PR DESCRIPTION
Just a small fix that should help with issue #22 

Specifying the jobname will force the outputs to be `texput.pdf` and `texput.log`, etc. in the temporary directory, even when using `\documentclass{article}` which seems to normally rename the outputs to `article.*`.