### PR TITLE
Add `precompiled` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,6 +114,15 @@ function latex(src, options) {
     // The path to where the user wants to save the error log file to.
     const userLogPath = options.errorLogs
 
+    // The path(s) to your precompiled files.
+    const precompiled = options.precompiled ? resolvePaths(options.precompiled) : null
+
+    const copyPrecompiled = (pathToPrecompiled) => {
+      fs.readdirSync(pathToPrecompiled).forEach(file =>
+        fs.copyFileSync(path.resolve(pathToPrecompiled, file), path.resolve(tempPath, file))
+      )
+    }
+
     // The current amount of times LaTeX has run so far.
     let completedPasses = 0
 
@@ -195,6 +204,9 @@ function latex(src, options) {
     }
 
     // Start the first run.
+    if (precompiled) {
+      Array.isArray(precompiled) ? precompiled.forEach(copyPrecompiled) : copyPrecompiled(precompiled)
+    }
     runLatex(inputStream)
   })
 

--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,8 @@ View more examples [here](https://github.com/saadq/node-latex/tree/master/exampl
 
 **options.inputs** \[String|Array<String>\] - The path (or an array of paths) to the directory which contains the assets necessary for the doc.
 
+**options.precompiled** \[String|Array<String>\] - The path  (or an array of paths) to the directory which contains the precompiled files necessary for the doc.
+
 **options.fonts** \[String|Array<String>\] - The path (or an array of paths) to the directory which contains the fonts necessary for the doc (you will most likely want to use this option if you're working with `fontspec`).
 
 **options.cmd** \[String\] - The command to run for your document (`pdflatex`, `xetex`, etc). `pdflatex` is the default.


### PR DESCRIPTION
Add option to copy precompiled files in order to
speed up the build.

By example, one can include bibtex files or toc files.