### PR TITLE
Avoid uncaught exception if there is a problem with options.errorLogs

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,6 +44,7 @@ function latex(src, options) {
       if (userLogPath) {
         const userLogStream = fs.createWriteStream(path.resolve(userLogPath))
         errorLogStream.pipe(userLogStream)
+        userLogStream.on('error', (userLogStreamErr) => handleErrors(userLogStreamErr))
       }
 
       const errors = []


### PR DESCRIPTION
If options.errorLogs is misunderstood and someone passes a directory instead of a file path or there is any other problem with that resulting stream it is impossible to catch that exception and the application crashes because of an uncaught exception.

This pull request should fix this issue.