### PR TITLE
Add `spawnCallback` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,4 @@
+import { ChildProcess } from 'child_process'
 import { Readable, Transform } from 'stream'
 
 /**
@@ -39,6 +40,12 @@ export interface LatexOptions {
    * to.
    */
   errorLogs?: string
+
+  /**
+   * A function to call on each LaTeX invocation. The only argument is an instance
+   * of ChildProcess.
+   */
+  spawnCallback?: (proc: ChildProcess) => void
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -162,6 +162,10 @@ function latex(src, options) {
     const runLatex = (inputStream) => {
       const tex = spawn(cmd, args, opts)
 
+      if (options.spawnCallback) {
+        options.spawnCallback(tex);
+      }
+
       inputStream.pipe(tex.stdin)
 
       // Prevent Node from crashing on compilation error.

--- a/readme.md
+++ b/readme.md
@@ -48,5 +48,7 @@ View more examples [here](https://github.com/saadq/node-latex/tree/master/exampl
 
 **options.errorLogs** \[String] - The path to the file where you want to save the contents of the error log to.
 
+**options.spawnCallback** \[Function] - A function to call on each LaTeX invocation. The only argument is an instance of `ChildProcess`.
+
 ## License
 MIT


### PR DESCRIPTION
This adds an optional callback to retrieve the spawned instance of `ChildProcess`.

I recently had to implement a timeout on LaTeX export, and this seems like the most straightforward way.